### PR TITLE
Throw exception on generator read

### DIFF
--- a/src/LineReader.php
+++ b/src/LineReader.php
@@ -16,11 +16,7 @@ final class LineReader
      */
     public static function readLines($filePath)
     {
-        if (!$fh = @fopen($filePath, 'r')) {
-            throw new \InvalidArgumentException('Cannot open file for reading: ' . $filePath);
-        }
-
-        return self::read($fh);
+        return self::read($filePath);
     }
 
     /**
@@ -29,21 +25,19 @@ final class LineReader
      */
     public static function readLinesBackwards($filePath)
     {
+        return self::readBackwards($filePath);
+    }
+
+    /**
+     * @param string $filePath
+     * @return \Generator
+     */
+    private static function read($filePath)
+    {
         if (!$fh = @fopen($filePath, 'r')) {
             throw new \InvalidArgumentException('Cannot open file for reading: ' . $filePath);
         }
 
-        $size = filesize($filePath);
-
-        return self::readBackwards($fh, $size);
-    }
-
-    /**
-     * @param resource $fh
-     * @return \Generator
-     */
-    private static function read($fh)
-    {
         while (false !== $line = fgets($fh)) {
             yield rtrim($line, "\n");
         }
@@ -59,18 +53,22 @@ final class LineReader
      * a newline character.
      *
      * @see http://stackoverflow.com/a/10494801/147634
-     * @param resource $fh
-     * @param int $pos
+     * @param string $filePath
      * @return \Generator
      */
-    private static function readBackwards($fh, $pos)
+    private static function readBackwards($filePath)
     {
-        $buffer = null;
-        $bufferSize = 4096;
+        if (!$fh = @fopen($filePath, 'r')) {
+            throw new \InvalidArgumentException('Cannot open file for reading: ' . $filePath);
+        }
 
+        $pos = filesize($filePath);
         if ($pos === 0) {
             return;
         }
+
+        $buffer = null;
+        $bufferSize = 4096;
 
         while (true) {
             if (isset($buffer[1])) { // faster than count($buffer) > 1

--- a/tests/LineReaderTest.php
+++ b/tests/LineReaderTest.php
@@ -33,12 +33,23 @@ class LineReaderTest extends \PHPUnit_Framework_TestCase
         new LineReader();
     }
 
+    public function testReadLinesExceptionIsLazy()
+    {
+        self::assertInstanceOf(\Generator::class, LineReader::readLines('/tmp/invalid-file.txt'));
+    }
+
     public function testReadLinesThrowsException()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot open file for reading: /tmp/invalid-file.txt');
 
-        LineReader::readLines('/tmp/invalid-file.txt');
+        iterator_to_array(LineReader::readLines('/tmp/invalid-file.txt'));
+    }
+
+
+    public function testReadLinesBackwardsExceptionIsLazy()
+    {
+        self::assertInstanceOf(\Generator::class, LineReader::readLinesBackwards('/tmp/invalid-file.txt'));
     }
 
     public function testReadLinesBackwardsThrowsException()
@@ -46,7 +57,7 @@ class LineReaderTest extends \PHPUnit_Framework_TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot open file for reading: /tmp/invalid-file.txt');
 
-        LineReader::readLinesBackwards('/tmp/invalid-file.txt');
+        iterator_to_array(LineReader::readLines('/tmp/invalid-file.txt'));
     }
 
     public function testReadsAllLines()


### PR DESCRIPTION
Right now, when passing a invalid filepath, an exception is thrown immediately 

```php
LineReader::readLines('/tmp/invalid-file.txt') // throws InvalidArgumentException
```

Due to the nature of generators we can defer the exception to the time when the generator is first read:

```php
$generator = LineReader::readLines('/tmp/invalid-file.txt') 
// No Exception up to this point
// code. code. code.

// The exception is thrown when the generator read
foreach ($generator as $line) {} // throws InvalidArgumentException
```

I am not sure however, which behavior should be preferred.